### PR TITLE
Fix iOS build workflow submission conditions

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -55,22 +55,15 @@ jobs:
         path: "**/*.ipa"
         retention-days: 30
     
-    - name: Download IPA artifact
-      if: ${{ inputs.submit != false }}
-      uses: actions/download-artifact@v4
-      with:
-        name: ios-app-${{ github.sha }}
-        path: ./artifacts
-    
     - name: Find IPA file
-      if: ${{ inputs.submit != false }}
+      if: ${{ github.event_name == 'push' || inputs.submit != false }}
       id: find_ipa
       run: |
-        IPA_FILE=$(find ./artifacts -name "*.ipa" -type f | head -n 1)
+        IPA_FILE=$(find . -name "*.ipa" -type f | head -n 1)
         echo "ipa_file=$IPA_FILE" >> $GITHUB_OUTPUT
     
     - name: Submit iOS to App Store
-      if: ${{ inputs.submit != false }}
+      if: ${{ github.event_name == 'push' || inputs.submit != false }}
       run: npx eas submit -p ios --path ${{ steps.find_ipa.outputs.ipa_file }} --non-interactive
       env:
         EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}


### PR DESCRIPTION
## Summary
- Fixed iOS build workflow submission conditions to properly handle both push events and workflow_dispatch events
- Removed redundant artifact download step that was causing unnecessary overhead
- Kept archive step in original position between build and submit

The workflow now properly submits to the App Store on pushes to main branch, and correctly evaluates the submit condition for manual workflow runs.