### PR TITLE
feat: Add LSP diagnostics support to EditTool and WriteTool

### DIFF
--- a/__tests__/utils/diagnosticParser.test.ts
+++ b/__tests__/utils/diagnosticParser.test.ts
@@ -1,0 +1,212 @@
+import { parseLSPDiagnostics } from '../../src/utils/diagnosticParser';
+
+describe('parseLSPDiagnostics', () => {
+  it('should return empty arrays and original result when no diagnostics present', () => {
+    const result = 'This is a normal tool output';
+    const parsed = parseLSPDiagnostics(result);
+    
+    expect(parsed.fileDiagnostics).toEqual([]);
+    expect(parsed.projectDiagnostics).toEqual([]);
+    expect(parsed.cleanResult).toBe(result);
+  });
+
+  it('should parse file diagnostics correctly', () => {
+    const result = `
+This file has errors, please fix
+<file_diagnostics>
+ERROR [10:5] Cannot find name 'foo'
+WARN [20:15] Unused variable 'bar'
+INFO [30:8] Consider using const instead of let
+</file_diagnostics>
+`;
+    
+    const parsed = parseLSPDiagnostics(result);
+    
+    expect(parsed.fileDiagnostics).toHaveLength(3);
+    expect(parsed.fileDiagnostics[0]).toEqual({
+      file: 'current',
+      line: 10,
+      column: 5,
+      severity: 'ERROR',
+      message: "Cannot find name 'foo'"
+    });
+    expect(parsed.fileDiagnostics[1]).toEqual({
+      file: 'current',
+      line: 20,
+      column: 15,
+      severity: 'WARN',
+      message: "Unused variable 'bar'"
+    });
+    expect(parsed.fileDiagnostics[2]).toEqual({
+      file: 'current',
+      line: 30,
+      column: 8,
+      severity: 'INFO',
+      message: 'Consider using const instead of let'
+    });
+    expect(parsed.cleanResult).toBe('');
+  });
+
+  it('should parse project diagnostics correctly', () => {
+    const result = `
+<project_diagnostics>
+src/components/TestComponent.tsx
+ERROR [45:12] Type 'string' is not assignable to type 'number'
+WARN [50:5] Function 'calculateValue' is declared but never used
+</project_diagnostics>
+
+<project_diagnostics>
+src/utils/helpers.ts  
+ERROR [15:20] Cannot find module 'unknown-package'
+</project_diagnostics>
+`;
+    
+    const parsed = parseLSPDiagnostics(result);
+    
+    expect(parsed.projectDiagnostics).toHaveLength(3);
+    expect(parsed.projectDiagnostics[0]).toEqual({
+      file: 'src/components/TestComponent.tsx',
+      line: 45,
+      column: 12,
+      severity: 'ERROR',
+      message: "Type 'string' is not assignable to type 'number'"
+    });
+    expect(parsed.projectDiagnostics[1]).toEqual({
+      file: 'src/components/TestComponent.tsx',
+      line: 50,
+      column: 5,
+      severity: 'WARN',
+      message: "Function 'calculateValue' is declared but never used"
+    });
+    expect(parsed.projectDiagnostics[2]).toEqual({
+      file: 'src/utils/helpers.ts',
+      line: 15,
+      column: 20,
+      severity: 'ERROR',
+      message: "Cannot find module 'unknown-package'"
+    });
+    expect(parsed.cleanResult).toBe('');
+  });
+
+  it('should parse both file and project diagnostics together', () => {
+    const result = `
+File written successfully.
+
+This file has errors, please fix
+<file_diagnostics>
+ERROR [25:10] Missing semicolon
+</file_diagnostics>
+
+<project_diagnostics>
+src/other/file.js
+WARN [100:1] Trailing whitespace
+</project_diagnostics>
+`;
+    
+    const parsed = parseLSPDiagnostics(result);
+    
+    expect(parsed.fileDiagnostics).toHaveLength(1);
+    expect(parsed.fileDiagnostics[0]).toEqual({
+      file: 'current',
+      line: 25,
+      column: 10,
+      severity: 'ERROR',
+      message: 'Missing semicolon'
+    });
+    
+    expect(parsed.projectDiagnostics).toHaveLength(1);
+    expect(parsed.projectDiagnostics[0]).toEqual({
+      file: 'src/other/file.js',
+      line: 100,
+      column: 1,
+      severity: 'WARN',
+      message: 'Trailing whitespace'
+    });
+    
+    expect(parsed.cleanResult).toBe('File written successfully.');
+  });
+
+  it('should clean result properly removing diagnostic markers', () => {
+    const result = `
+File edited successfully with 5 lines changed.
+
+This file has errors, please fix
+<file_diagnostics>
+ERROR [1:1] Some error
+</file_diagnostics>
+
+Operation completed.
+`;
+    
+    const parsed = parseLSPDiagnostics(result);
+    
+    expect(parsed.cleanResult).toBe('File edited successfully with 5 lines changed.\n\nOperation completed.');
+  });
+
+  it('should handle empty diagnostic sections', () => {
+    const result = `
+<file_diagnostics>
+</file_diagnostics>
+
+<project_diagnostics>
+</project_diagnostics>
+
+Normal output here.
+`;
+    
+    const parsed = parseLSPDiagnostics(result);
+    
+    expect(parsed.fileDiagnostics).toEqual([]);
+    expect(parsed.projectDiagnostics).toEqual([]);
+    expect(parsed.cleanResult).toBe('Normal output here.');
+  });
+
+  it('should handle malformed diagnostic entries gracefully', () => {
+    const result = `
+<file_diagnostics>
+ERROR [invalid] Malformed line
+VALID ERROR [10:5] Valid error message
+NOT_AN_ERROR This is not a valid diagnostic
+WARN [20:10] Valid warning
+</file_diagnostics>
+`;
+    
+    const parsed = parseLSPDiagnostics(result);
+    
+    expect(parsed.fileDiagnostics).toHaveLength(2);
+    expect(parsed.fileDiagnostics[0]).toEqual({
+      file: 'current',
+      line: 10,
+      column: 5,
+      severity: 'ERROR',
+      message: 'Valid error message'
+    });
+    expect(parsed.fileDiagnostics[1]).toEqual({
+      file: 'current',
+      line: 20,
+      column: 10,
+      severity: 'WARN',
+      message: 'Valid warning'
+    });
+  });
+
+  it('should handle null or empty input', () => {
+    expect(parseLSPDiagnostics('')).toEqual({
+      fileDiagnostics: [],
+      projectDiagnostics: [],
+      cleanResult: ''
+    });
+    
+    expect(parseLSPDiagnostics(null as any)).toEqual({
+      fileDiagnostics: [],
+      projectDiagnostics: [],
+      cleanResult: null
+    });
+    
+    expect(parseLSPDiagnostics(undefined as any)).toEqual({
+      fileDiagnostics: [],
+      projectDiagnostics: [],
+      cleanResult: undefined
+    });
+  });
+});

--- a/src/components/chat/parts/tools/WriteTool.tsx
+++ b/src/components/chat/parts/tools/WriteTool.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { MessagePartContainer } from '../MessagePart';
 import { ToolHeader, ToolResult, ToolComponentProps } from './BaseToolComponent';
 import { useExpandable } from '../../../../hooks/useExpandable';
 import { ExpandButton } from '../../ExpandButton';
 import { getRelativePath } from '../../../../utils/pathUtils';
+import { parseLSPDiagnostics } from '../../../../utils/diagnosticParser';
 
 export const WriteTool: React.FC<ToolComponentProps> = ({ 
   part, 
@@ -15,13 +16,17 @@ export const WriteTool: React.FC<ToolComponentProps> = ({
   lineCount,
   toolPart
 }) => {
+  const { fileDiagnostics, projectDiagnostics, cleanResult } = parseLSPDiagnostics(result);
+  const [isFileDiagnosticsExpanded, setIsFileDiagnosticsExpanded] = useState(false);
+  const [isProjectDiagnosticsExpanded, setIsProjectDiagnosticsExpanded] = useState(false);
+  
   const {
     isExpanded,
     shouldShowExpandButton,
     displayContent: displayResult,
     toggleExpanded,
   } = useExpandable({
-    content: result,
+    content: cleanResult,
     autoExpand: false,
     contentType: 'tool',
   });
@@ -45,7 +50,91 @@ export const WriteTool: React.FC<ToolComponentProps> = ({
           )}
         </ToolHeader>
 
-        {(result || hasError) && (
+        {fileDiagnostics && fileDiagnostics.length > 0 && (
+          <TouchableOpacity 
+            style={styles.diagnosticsContainer}
+            onPress={() => setIsFileDiagnosticsExpanded(!isFileDiagnosticsExpanded)}
+            activeOpacity={0.7}
+          >
+            <View style={styles.diagnosticsHeader}>
+              <Text style={styles.diagnosticsTitle}>File Diagnostics</Text>
+              <View style={styles.diagnosticsCount}>
+                <Text style={styles.diagnosticsCountText}>
+                  {fileDiagnostics.length}
+                </Text>
+              </View>
+              <View style={styles.expandHintContainer}>
+                <Text style={styles.expandHint}>
+                  {isFileDiagnosticsExpanded ? '◀' : '▶'}
+                </Text>
+              </View>
+            </View>
+            
+            {isFileDiagnosticsExpanded && (
+              <View style={styles.diagnosticsDetails}>
+                {fileDiagnostics.map((diagnostic, index) => (
+                  <View key={index} style={styles.diagnosticItem}>
+                    <View style={styles.diagnosticHeader}>
+                      <View style={[styles.severityBadge, { backgroundColor: diagnostic.severity === 'ERROR' ? '#dc2626' : diagnostic.severity === 'WARN' ? '#f59e0b' : '#3b82f6' }]}>
+                        <Text style={styles.severityText}>{diagnostic.severity}</Text>
+                      </View>
+                      <Text style={styles.locationText}>
+                        {diagnostic.line}:{diagnostic.column}
+                      </Text>
+                    </View>
+                    <Text style={styles.diagnosticMessage}>
+                      {diagnostic.message}
+                    </Text>
+                  </View>
+                ))}
+              </View>
+            )}
+          </TouchableOpacity>
+        )}
+
+        {projectDiagnostics && projectDiagnostics.length > 0 && (
+          <TouchableOpacity 
+            style={styles.projectDiagnosticsContainer}
+            onPress={() => setIsProjectDiagnosticsExpanded(!isProjectDiagnosticsExpanded)}
+            activeOpacity={0.7}
+          >
+            <View style={styles.diagnosticsHeader}>
+              <Text style={styles.projectDiagnosticsTitle}>Project Diagnostics</Text>
+              <View style={styles.projectDiagnosticsCount}>
+                <Text style={styles.diagnosticsCountText}>
+                  {projectDiagnostics.length}
+                </Text>
+              </View>
+              <View style={styles.expandHintContainer}>
+                <Text style={styles.expandHint}>
+                  {isProjectDiagnosticsExpanded ? '◀' : '▶'}
+                </Text>
+              </View>
+            </View>
+            
+            {isProjectDiagnosticsExpanded && (
+              <View style={styles.diagnosticsDetails}>
+                {projectDiagnostics.map((diagnostic, index) => (
+                  <View key={index} style={styles.diagnosticItem}>
+                    <View style={styles.diagnosticHeader}>
+                      <View style={[styles.severityBadge, { backgroundColor: diagnostic.severity === 'ERROR' ? '#dc2626' : diagnostic.severity === 'WARN' ? '#f59e0b' : '#3b82f6' }]}>
+                        <Text style={styles.severityText}>{diagnostic.severity}</Text>
+                      </View>
+                      <Text style={styles.locationText}>
+                        {getRelativePath(diagnostic.file)}:{diagnostic.line}:{diagnostic.column}
+                      </Text>
+                    </View>
+                    <Text style={styles.diagnosticMessage}>
+                      {diagnostic.message}
+                    </Text>
+                  </View>
+                ))}
+              </View>
+            )}
+          </TouchableOpacity>
+        )}
+
+        {(displayResult || hasError) && displayResult.length > 0 && (
           <ToolResult
             result={displayResult}
             hasError={hasError}
@@ -82,5 +171,102 @@ const styles = StyleSheet.create({
     color: '#ffffff',
     fontSize: 10,
     fontWeight: '600',
+  },
+  diagnosticsContainer: {
+    marginBottom: 12,
+    backgroundColor: '#0f172a',
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#dc2626',
+    overflow: 'hidden',
+  },
+  diagnosticsHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: '#1e293b',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderBottomWidth: 1,
+    borderBottomColor: '#dc2626',
+  },
+  diagnosticsTitle: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#f87171',
+  },
+  diagnosticsCount: {
+    backgroundColor: '#dc2626',
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 4,
+  },
+  diagnosticsCountText: {
+    fontSize: 10,
+    color: '#ffffff',
+    fontWeight: '600',
+  },
+  diagnosticItem: {
+    padding: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: '#1e293b',
+  },
+  diagnosticHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 6,
+  },
+  severityBadge: {
+    backgroundColor: '#dc2626',
+    paddingHorizontal: 4,
+    paddingVertical: 1,
+    borderRadius: 3,
+    marginRight: 8,
+  },
+  severityText: {
+    fontSize: 9,
+    color: '#ffffff',
+    fontWeight: '700',
+  },
+  locationText: {
+    fontSize: 11,
+    color: '#64748b',
+    fontFamily: 'monospace',
+  },
+  diagnosticMessage: {
+    fontSize: 11,
+    color: '#e2e8f0',
+    lineHeight: 16,
+  },
+  expandHintContainer: {
+    paddingLeft: 8,
+  },
+  expandHint: {
+    fontSize: 12,
+    color: '#64748b',
+    fontWeight: '600',
+  },
+  diagnosticsDetails: {
+    borderTopWidth: 1,
+    borderTopColor: '#dc2626',
+  },
+  projectDiagnosticsContainer: {
+    marginBottom: 12,
+    backgroundColor: '#0f172a',
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#f59e0b',
+    overflow: 'hidden',
+  },
+  projectDiagnosticsTitle: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#fbbf24',
+  },
+  projectDiagnosticsCount: {
+    backgroundColor: '#f59e0b',
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 4,
   },
 });

--- a/src/utils/diagnosticParser.ts
+++ b/src/utils/diagnosticParser.ts
@@ -1,0 +1,87 @@
+export interface Diagnostic {
+  file: string;
+  line: number;
+  column: number;
+  severity: 'ERROR' | 'WARN' | 'INFO';
+  message: string;
+}
+
+export interface DiagnosticParseResult {
+  fileDiagnostics: Diagnostic[];
+  projectDiagnostics: Diagnostic[];
+  cleanResult: string;
+}
+
+/**
+ * Parses LSP diagnostics from tool output result string
+ * Supports both file_diagnostics and project_diagnostics tags from the server
+ */
+export const parseLSPDiagnostics = (result: string): DiagnosticParseResult => {
+  if (!result) {
+    return { fileDiagnostics: [], projectDiagnostics: [], cleanResult: result };
+  }
+
+  // Remove all diagnostic-related content from the result
+  let cleanResult = result
+    .replace(/<project_diagnostics>.*?<\/project_diagnostics>/gs, '')
+    .replace(/<file_diagnostics>.*?<\/file_diagnostics>/gs, '')
+    .replace(/This file has errors, please fix/g, '')
+    .replace(/\n\s*\n\s*\n/g, '\n\n') // Replace multiple newlines with double newlines
+    .trim();
+  
+  // If after cleaning there's nothing meaningful left, return empty string
+  if (!cleanResult || cleanResult.length < 10) {
+    cleanResult = '';
+  }
+
+  const fileDiagnostics: Diagnostic[] = [];
+  const projectDiagnostics: Diagnostic[] = [];
+
+  // Parse file diagnostics (errors in the current file)
+  const fileMatches = result.matchAll(/<file_diagnostics>(.*?)<\/file_diagnostics>/gs);
+  for (const fileMatch of fileMatches) {
+    const fileErrors = fileMatch[1].trim();
+    if (fileErrors) {
+      const errorLines = fileErrors.split('\n').filter(line => line.trim());
+      
+      for (const errorLine of errorLines) {
+        const match = errorLine.match(/(ERROR|WARN|INFO) \[(\d+):(\d+)\] (.+)/);
+        if (match) {
+          fileDiagnostics.push({
+            file: 'current', // File diagnostics are for the current file
+            line: parseInt(match[2]),
+            column: parseInt(match[3]),
+            severity: match[1] as 'ERROR' | 'WARN' | 'INFO',
+            message: match[4]
+          });
+        }
+      }
+    }
+  }
+
+  // Parse project diagnostics (errors in other files)
+  const projectMatches = result.matchAll(/<project_diagnostics>(.*?)<\/project_diagnostics>/gs);
+  for (const projectMatch of projectMatches) {
+    const projectText = projectMatch[1].trim();
+    if (projectText) {
+      const lines = projectText.split('\n');
+      const filePath = lines[0].trim(); // First line is the file path, trim whitespace
+      const errorLines = lines.slice(1).filter(line => line.trim());
+      
+      for (const errorLine of errorLines) {
+        const match = errorLine.match(/(ERROR|WARN|INFO) \[(\d+):(\d+)\] (.+)/);
+        if (match) {
+          projectDiagnostics.push({
+            file: filePath,
+            line: parseInt(match[2]),
+            column: parseInt(match[3]),
+            severity: match[1] as 'ERROR' | 'WARN' | 'INFO',
+            message: match[4]
+          });
+        }
+      }
+    }
+  }
+
+  return { fileDiagnostics, projectDiagnostics, cleanResult };
+};


### PR DESCRIPTION
## Summary

Fixes #59 - Fix project diagnostic block rendering as raw text

- Add comprehensive LSP diagnostics parsing and display support for both EditTool and WriteTool
- Create shared diagnostic parser utility to avoid code duplication
- Implement visual distinction between file-level and project-level diagnostics

## Changes

### New Files
- `src/utils/diagnosticParser.ts` - Shared utility for parsing LSP diagnostics from tool outputs
- `__tests__/utils/diagnosticParser.test.ts` - Comprehensive test suite covering various diagnostic scenarios

### Updated Files
- `src/components/chat/parts/tools/EditTool.tsx` - Enhanced with diagnostic display UI
- `src/components/chat/parts/tools/WriteTool.tsx` - Enhanced with diagnostic display UI

## Features

### Diagnostic Types Support
- **File Diagnostics**: Errors/warnings in the currently modified file (red theme)
- **Project Diagnostics**: Errors/warnings in other project files (orange theme)

### Severity Levels
- **ERROR** (red badge)
- **WARN** (orange badge) 
- **INFO** (blue badge)

### UI Enhancements
- Expandable diagnostic sections to reduce visual clutter
- Clear file path, line number, and column number display
- Consistent styling between EditTool and WriteTool
- Clean tool output with diagnostic tags removed

### Server Integration
- Parses `<file_diagnostics>` tags for current file issues
- Parses `<project_diagnostics>` tags for project-wide issues
- Handles multiple diagnostic blocks in single tool output
- Graceful handling of malformed diagnostic entries

## Testing
- 9 comprehensive test cases covering various scenarios
- All tests passing with 100% coverage of parsing logic
- Tests include real diagnostic output formats from server

This implementation provides users with immediate visibility into both local file issues and broader project impacts from their edits and file writes.