### PR TITLE
Update git branch on session.idle events

### DIFF
--- a/app/(tabs)/chat.tsx
+++ b/app/(tabs)/chat.tsx
@@ -247,10 +247,14 @@ const [commandStatus, setCommandStatus] = useState<string | null>(null);
 
     loadChutesQuota();
     
-    // Also subscribe to session.idle events to refresh quota
+    // Also subscribe to session.idle events to refresh quota and git branch
     const unsubscribe = onSessionIdle((sessionId: string) => {
       console.log(`[Chutes] Session ${sessionId} became idle, refreshing quota`);
       loadChutesQuota();
+      
+      // Update git branch when session becomes idle
+      console.log('Git branch update triggered by session.idle event');
+      fetchGitBranch();
     });
     
     return unsubscribe;


### PR DESCRIPTION
This PR modifies the chat screen to automatically update the git branch information whenever a session becomes idle. This ensures that the branch information displayed in the chat header stays current without requiring manual refresh.