### PR TITLE
feat: enhance iOS workflows with split preview/production builds and …

### DIFF
--- a/.github/workflows/ios-preview.yml
+++ b/.github/workflows/ios-preview.yml
@@ -1,0 +1,55 @@
+name: iOS Preview Build
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build-preview:
+    runs-on: macos-15
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    
+    - name: Setup Xcode 16.4
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: '16.4'
+    
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+        cache: 'npm'
+    
+    - name: Cache Expo
+      uses: actions/cache@v4
+      with:
+        path: ~/.expo
+        key: ${{ runner.os }}-expo-preview-${{ hashFiles('**/package-lock.json', 'app.json', 'eas.json') }}
+        restore-keys: |
+          ${{ runner.os }}-expo-preview-
+          ${{ runner.os }}-expo-
+    
+    - name: Install dependencies
+      run: |
+        npm install -g eas-cli
+        npm ci
+    
+    - name: Build iOS preview (local)
+      run: npm run build:ios:local
+      env:
+        EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+    
+    - name: Upload IPA artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ios-preview-${{ github.sha }}
+        path: "**/*.ipa"
+        retention-days: 7
+    
+    - name: Generate workflow summary using OTA host
+      run: |
+        npm run ota-host -- --output markdown >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ios-preview.yml
+++ b/.github/workflows/ios-preview.yml
@@ -43,13 +43,28 @@ jobs:
       env:
         EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
     
-    - name: Upload IPA artifact
+    - name: Generate OTA artifacts using ota-host script
+      run: |
+        # Generate all artifacts using ota-host script output modes
+        npm run ota-host -- --output json > ipa-info.json
+        npm run ota-host -- --output html > install.html
+        npm run ota-host -- --output markdown > build-summary.md
+        npm run ota-host -- --output manifest > manifest.plist
+        
+        echo 'Generated OTA artifacts:'
+        echo '- IPA file(s): Ready for local installation'
+        echo '- manifest.plist: For OTA installation (use with ota-host script)'
+        echo '- install.html: Standalone installation page'
+        echo '- build-summary.md: Build details and instructions'
+    
+    - name: Upload artifacts (IPA, manifest, HTML)
       uses: actions/upload-artifact@v4
       with:
         name: ios-preview-${{ github.sha }}
-        path: "**/*.ipa"
+        path: |
+          **/*.ipa
+          manifest.plist
+          install.html
+          build-summary.md
+          ipa-info.json
         retention-days: 7
-    
-    - name: Generate workflow summary using OTA host
-      run: |
-        npm run ota-host -- --output markdown >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ios-production.yml
+++ b/.github/workflows/ios-production.yml
@@ -1,8 +1,11 @@
-name: iOS Build
+name: iOS Production Build
 
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'app.json'
+      - 'package.json'
   workflow_dispatch:
     inputs:
       submit:
@@ -12,7 +15,7 @@ on:
         type: boolean
 
 jobs:
-  build-ios:
+  build-production:
     runs-on: macos-15
     
     steps:
@@ -34,8 +37,9 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~/.expo
-        key: ${{ runner.os }}-expo-${{ hashFiles('**/package-lock.json', 'app.json', 'eas.json') }}
+        key: ${{ runner.os }}-expo-prod-${{ hashFiles('**/package-lock.json', 'app.json', 'eas.json') }}
         restore-keys: |
+          ${{ runner.os }}-expo-prod-
           ${{ runner.os }}-expo-
     
     - name: Install dependencies
@@ -51,7 +55,7 @@ jobs:
     - name: Upload IPA artifact
       uses: actions/upload-artifact@v4
       with:
-        name: ios-app-${{ github.sha }}
+        name: ios-production-${{ github.sha }}
         path: "**/*.ipa"
         retention-days: 30
     
@@ -61,6 +65,7 @@ jobs:
       run: |
         IPA_FILE=$(find . -name "*.ipa" -type f | head -n 1)
         echo "ipa_file=$IPA_FILE" >> $GITHUB_OUTPUT
+        echo "Found production IPA: $IPA_FILE"
     
     - name: Submit iOS to App Store
       if: ${{ github.event_name == 'push' || inputs.submit != false }}

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -32,7 +32,7 @@ export default function SettingsScreen() {
   const [githubTokenInput, setGithubTokenInput] = useState('');
   const [isLoadingGithubToken, setIsLoadingGithubToken] = useState(false);
    const [isTestingGithubToken, setIsTestingGithubToken] = useState(false);
-  const [showDevSection, setShowDevSection] = useState(__DEV__);
+  const [showDevSection] = useState(__DEV__);
 
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-mobile",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-mobile",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",
         "@hey-api/client-fetch": "^0.13.1",
@@ -25,6 +25,7 @@
         "expo-clipboard": "~7.1.5",
         "expo-constants": "~17.1.7",
         "expo-dev-client": "~5.2.4",
+        "expo-document-picker": "~13.1.6",
         "expo-font": "~13.3.2",
         "expo-haptics": "~14.1.4",
         "expo-image": "~2.4.0",
@@ -75,6 +76,26 @@
         "react-test-renderer": "^19.0.0",
         "tsx": "^4.20.4",
         "typescript": "~5.8.3"
+      }
+    },
+    "expo-ssh": {
+      "version": "0.1.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config-plugins": "~10.1.1",
+        "@expo/config-types": "^52.0.0"
+      },
+      "devDependencies": {
+        "@types/react": "~19.0.0",
+        "expo": "~53.0.0",
+        "expo-module-scripts": "^4.1.10",
+        "react-native": "0.79.1"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -8896,6 +8917,15 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/expo-dev-menu-interface/-/expo-dev-menu-interface-1.10.0.tgz",
       "integrity": "sha512-NxtM/qot5Rh2cY333iOE87dDg1S8CibW+Wu4WdLua3UMjy81pXYzAGCZGNOeY7k9GpNFqDPNDXWyBSlk9r2pBg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-document-picker": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/expo-document-picker/-/expo-document-picker-13.1.6.tgz",
+      "integrity": "sha512-8FTQPDOkyCvFN/i4xyqzH7ELW4AsB6B3XBZQjn1FEdqpozo6rpNJRr7sWFU/93WrLgA9FJEKpKbyr6XxczK6BA==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "typecheck": "tsc --noEmit",
     "test": "jest",
     "test:ci": "jest --no-watch --watchAll=false --silent",
+
     "generate-api": "tsx scripts/generate-api-with-version.ts",
     "events": "tsx scripts/event-listener.ts",
     "ota-host": "tsx scripts/ota-host.ts",
@@ -65,6 +66,7 @@
     "expo-symbols": "~0.4.5",
     "expo-system-ui": "~5.0.11",
     "expo-web-browser": "~14.2.0",
+
     "express": "^5.1.0",
     "plist": "^3.1.0",
     "react": "^19.0.0",
@@ -79,7 +81,8 @@
     "react-native-sse": "^1.2.1",
     "react-native-web": "^0.20.0",
     "react-native-webview": "13.13.5",
-    "react-syntax-highlighter": "^15.6.1"
+    "react-syntax-highlighter": "^15.6.1",
+    "expo-document-picker": "~13.1.6"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -59,7 +59,7 @@ export interface CLIArguments {
   ipa?: string;
   help?: boolean;
   once?: boolean;
-  output?: 'server' | 'json' | 'markdown' | 'html';
+  output?: 'server' | 'json' | 'markdown' | 'html' | 'manifest';
 }
 
 export interface CertificateFiles {

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -59,6 +59,7 @@ export interface CLIArguments {
   ipa?: string;
   help?: boolean;
   once?: boolean;
+  output?: 'server' | 'json' | 'markdown' | 'html';
 }
 
 export interface CertificateFiles {

--- a/src/hooks/useOTAServer.ts
+++ b/src/hooks/useOTAServer.ts
@@ -71,8 +71,8 @@ export const useOTAServer = () => {
         version: '1.0.0',
         displayName: baseName,
         buildNumber: '1',
-        size: fileInfo.exists ? (fileInfo as any).size || 0 : 0,
-        modifiedTime: new Date(fileInfo.exists ? (fileInfo as any).modificationTime || Date.now() : Date.now())
+        size: fileInfo.exists ? fileInfo.size || 0 : 0,
+        modifiedTime: new Date(fileInfo.exists ? fileInfo.modificationTime * 1000 || Date.now() : Date.now())
       };
     } catch (error) {
       console.error('Error extracting IPA metadata:', error);

--- a/src/hooks/useOTAServer.ts
+++ b/src/hooks/useOTAServer.ts
@@ -1,0 +1,182 @@
+import { useState, useCallback } from 'react';
+import { Alert } from 'react-native';
+import * as DocumentPicker from 'expo-document-picker';
+import * as FileSystem from 'expo-file-system';
+
+interface IPAInfo {
+  path: string;
+  bundleId: string;
+  version: string;
+  displayName: string;
+  buildNumber?: string;
+  size: number;
+  modifiedTime: Date;
+}
+
+interface OTAServerState {
+  isRunning: boolean;
+  serverUrl?: string;
+  ipaInfo?: IPAInfo;
+  error?: string;
+}
+
+export const useOTAServer = () => {
+  const [serverState, setServerState] = useState<OTAServerState>({
+    isRunning: false
+  });
+
+  const selectIPAFile = useCallback(async () => {
+    try {
+      const result = await DocumentPicker.getDocumentAsync({
+        type: 'application/octet-stream', // IPA files
+        copyToCacheDirectory: true,
+      });
+
+      if (result.canceled) {
+        return null;
+      }
+
+      const file = result.assets[0];
+      
+      // Validate that it's an IPA file
+      if (!file.name.toLowerCase().endsWith('.ipa')) {
+        Alert.alert('Invalid File', 'Please select a valid IPA file.');
+        return null;
+      }
+
+      return {
+        uri: file.uri,
+        name: file.name,
+        size: file.size || 0,
+      };
+    } catch (error) {
+      console.error('Error selecting IPA file:', error);
+      Alert.alert('Error', 'Failed to select IPA file. Please try again.');
+      return null;
+    }
+  }, []);
+
+  const extractIPAMetadata = useCallback(async (ipaPath: string): Promise<IPAInfo | null> => {
+    try {
+      // For now, return basic metadata from filename
+      // In a real implementation, you'd extract from the IPA's Info.plist
+      const fileName = ipaPath.split('/').pop() || 'Unknown';
+      const baseName = fileName.replace('.ipa', '');
+      
+      const fileInfo = await FileSystem.getInfoAsync(ipaPath);
+      
+      return {
+        path: ipaPath,
+        bundleId: `com.dev.${baseName.toLowerCase().replace(/[^a-z0-9]/g, '')}`,
+        version: '1.0.0',
+        displayName: baseName,
+        buildNumber: '1',
+        size: fileInfo.exists ? (fileInfo as any).size || 0 : 0,
+        modifiedTime: new Date(fileInfo.exists ? (fileInfo as any).modificationTime || Date.now() : Date.now())
+      };
+    } catch (error) {
+      console.error('Error extracting IPA metadata:', error);
+      return null;
+    }
+  }, []);
+
+  const startOTAServer = useCallback(async (ipaFile: { uri: string; name: string; size: number }) => {
+    try {
+      setServerState({ isRunning: true });
+
+      // Extract metadata
+      const ipaInfo = await extractIPAMetadata(ipaFile.uri);
+      if (!ipaInfo) {
+        throw new Error('Failed to extract IPA metadata');
+      }
+
+      // For React Native, we can't directly run the Node.js script
+      // Instead, we'll show instructions for running it manually
+      const serverUrl = 'http://localhost:8443';
+      
+      setServerState({
+        isRunning: true,
+        serverUrl,
+        ipaInfo,
+      });
+
+      // Show instructions to user
+      Alert.alert(
+        'OTA Server Instructions',
+        `To serve your IPA file:\n\n1. Copy the IPA file to your project directory\n2. Run: npm run ota-host:dev\n3. The server will be available at ${serverUrl}\n\nIPA: ${ipaInfo.displayName} v${ipaInfo.version}`,
+        [
+          {
+            text: 'Copy Instructions',
+            onPress: () => {
+              // In a real implementation, you could copy to clipboard
+              console.log('Copy instructions to clipboard');
+            }
+          },
+          { text: 'OK' }
+        ]
+      );
+
+    } catch (error) {
+      console.error('Error starting OTA server:', error);
+      setServerState({
+        isRunning: false,
+        error: error instanceof Error ? error.message : 'Unknown error'
+      });
+      Alert.alert('Error', 'Failed to start OTA server. Please try again.');
+    }
+  }, [extractIPAMetadata]);
+
+  const stopOTAServer = useCallback(() => {
+    setServerState({ isRunning: false });
+    Alert.alert('OTA Server', 'Server stopped. You can manually stop the npm process if it\'s still running.');
+  }, []);
+
+  const generateManifest = useCallback(async (ipaInfo: IPAInfo, baseUrl: string) => {
+    const manifest = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>items</key>
+    <array>
+        <dict>
+            <key>assets</key>
+            <array>
+                <dict>
+                    <key>kind</key>
+                    <string>software-package</string>
+                    <key>url</key>
+                    <string>${baseUrl}/latest.ipa</string>
+                </dict>
+            </array>
+            <key>metadata</key>
+            <dict>
+                <key>bundle-identifier</key>
+                <string>${ipaInfo.bundleId}</string>
+                <key>bundle-version</key>
+                <string>${ipaInfo.version}</string>
+                <key>kind</key>
+                <string>software</string>
+                <key>title</key>
+                <string>${ipaInfo.displayName}</string>
+            </dict>
+        </dict>
+    </array>
+</dict>
+</plist>`;
+
+    return manifest;
+  }, []);
+
+  const getInstallUrl = useCallback((serverUrl: string) => {
+    return `itms-services://?action=download-manifest&url=${encodeURIComponent(`${serverUrl}/manifest.plist`)}`;
+  }, []);
+
+  return {
+    serverState,
+    selectIPAFile,
+    startOTAServer,
+    stopOTAServer,
+    generateManifest,
+    getInstallUrl,
+  };
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,8 @@
     "**/*.tsx",
     ".expo/types/**/*.ts",
     "expo-env.d.ts"
+  ],
+  "exclude": [
+    "expo-ssh/**/*"
   ]
 }


### PR DESCRIPTION
…OTA host output modes

- Split ios-build.yml into focused ios-preview.yml and ios-production.yml workflows
- Preview workflow: builds on all main pushes using build:ios:local, generates workflow summary
- Production workflow: builds only on app.json/package.json changes, submits to App Store
- Add --output flag to ota-host.ts supporting json, markdown, html modes for CI/CD integration
- Workflow summary now generated using ota-host script to maintain DRY principles
- Enhanced metadata extraction and GitHub Actions context integration